### PR TITLE
actually use camera arg and remote_device_ip

### DIFF
--- a/sick_visionary_t_driver/launch/sick_visionary_t_driver.launch
+++ b/sick_visionary_t_driver/launch/sick_visionary_t_driver.launch
@@ -2,12 +2,12 @@
 <launch>
 
   <arg name="camera" default="sick_visionary_t_driver" />
+  <!-- IP address if the Visionary-T device, default: 192.168.1.10 -->
+  <arg name="remote_device_ip" default="192.168.1.10" />
 
   <node pkg="sick_visionary_t_driver" type="sick_visionary_t_driver_node" name="$(arg camera)" output="screen" >
-    <!-- IP address if the Visionary-T device, default: 192.168.1.10 -->
-    <param name="remote_device_ip" value="192.168.1.10" />
-
-    <param name="frame_id" value="camera" />
+    <param name="frame_id" value="$(arg camera)" />
+    <param name="remote_device_ip" value="$(arg remote_device_ip)" />
   </node>
 
 </launch>


### PR DESCRIPTION
+ Adds launch arg for `remote_device_ip` as arg for the driver node.
+ Actually use the `frame_id` provided by the launch arg.