### PR TITLE
Add default value for CameraParams while parsing from XML

### DIFF
--- a/sick_visionary_t_driver/include/sick_visionary_t_driver/data.h
+++ b/sick_visionary_t_driver/include/sick_visionary_t_driver/data.h
@@ -206,15 +206,15 @@ private:
 		}
 		ROS_ASSERT(i==16);
 		
-		cameraParams_.fx = ds.get<double>("CameraMatrix.FX");
-		cameraParams_.fy = ds.get<double>("CameraMatrix.FY");
-		cameraParams_.cx = ds.get<double>("CameraMatrix.CX");
-		cameraParams_.cy = ds.get<double>("CameraMatrix.CY");
+		cameraParams_.fx = ds.get<double>("CameraMatrix.FX", 0.0);
+		cameraParams_.fy = ds.get<double>("CameraMatrix.FY", 0.0);
+		cameraParams_.cx = ds.get<double>("CameraMatrix.CX", 0.0);
+		cameraParams_.cy = ds.get<double>("CameraMatrix.CY", 0.0);
 		
-		cameraParams_.k1 = ds.get<double>("CameraDistortionParams.K1");
-		cameraParams_.k2 = ds.get<double>("CameraDistortionParams.K2");
+		cameraParams_.k1 = ds.get<double>("CameraDistortionParams.K1", 0.0);
+		cameraParams_.k2 = ds.get<double>("CameraDistortionParams.K2", 0.0);
 		
-		cameraParams_.f2rc = ds.get<double>("FocalToRayCross");
+		cameraParams_.f2rc = ds.get<double>("FocalToRayCross", 0.0);
 	
         // extract data format from XML (although it does not change)
         std::string data_type;


### PR DESCRIPTION
These values are obtained from Code Example for driver DC0013770/V3SXX5-1_Volume_1.6.0.29891R/Integration/ProgrammingExamples/C++/sick_visionary_cpp_samples/sick_visionary_cpp_shared/src/VisionaryTMiniData.cpp

(downloaded here: https://cdn.sick.com/media/zip/0/70/770/DC0013770.ZIP https://www.sick.com/br/en/machine-vision/3d-machine-vision/visionary-t-mini/v3s105-1aaaaaa/p/p665983?ff_data=JmZmX2lkPXA2NjU5ODMmZmZfbWFzdGVySWQ9cDY2NTk4MyZmZl90aXRsZT1WM1MxMDUtMUFBQUFBQSZmZl9xdWVyeT0mZmZfcG9zPTEmZmZfb3JpZ1Bvcz0xJmZmX3BhZ2U9MSZmZl9wYWdlU2l6ZT0yNCZmZl9vcmlnUGFnZVNpemU9MjQmZmZfc2ltaT05MS4w)